### PR TITLE
Add raw string marker to regexp

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -69,7 +69,7 @@ def _get_signature_regex(ns_prefix=None):
     tag = "Signature"
     if ns_prefix is not None:
         tag = ns_prefix + ":" + tag
-    return re.compile(ensure_bytes("<{t}[>\s].*?</{t}>".format(t=tag)), flags=re.DOTALL)
+    return re.compile(ensure_bytes(r"<{t}[>\s].*?</{t}>".format(t=tag)), flags=re.DOTALL)
 
 def _get_schema():
     global _schema


### PR DESCRIPTION
The regexp contains a single \s that would need to be escaped. So just add a 'r' to make this a raw string.