### PR TITLE
set default reference URI as part of enveloped signature

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -210,6 +210,11 @@ class xmldsig(object):
                 raise InvalidInput("Enveloped signature input contains more than one placeholder")
 
             self._reference_uri = ""
+            # get signed data id attribute value for reference uri  
+            payloadId = self.payload.get("Id", self.payload.get("ID"))
+            if payloadId is not None:
+                # set default reference uri based on data id attribute value
+                self._reference_uri = "#{}".format(payloadId)            
         elif method == methods.detached:
             if self._reference_uri is None:
                 self._reference_uri = "#{}".format(self.payload.get("Id", self.payload.get("ID", "object")))


### PR DESCRIPTION
Some SaaS providers supporting SSO using SAML may reject signed assertion if enveloped signature has no (or empty) reference URI.
The suggested enhancement to the enveloped signature functionality looks for and specifies the reference URI based on the signed data id attribute value, when one is available.