### PR TITLE
Fixes for #47 and #41

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -612,6 +612,7 @@ class xmldsig(object):
             root = fromstring(self.data, parser=parser)
         else:
             root = self.data
+        #HACK: deep copy won't keep root's namespaces resulting in an invalid digest
         c14n_root = fromstring(etree.tostring(root))
 
         if root.tag == ds_tag("Signature"):

--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -20,6 +20,7 @@ from pyasn1.type import univ
 from pyasn1.codec.der import encoder as der_encoder, decoder as der_decoder
 
 from .util import bytes_to_long, long_to_bytes, strip_pem_header, add_pem_header, ensure_bytes, ensure_str
+from collections import namedtuple
 
 methods = Enum("Methods", "enveloped enveloping detached")
 
@@ -99,6 +100,19 @@ def _get_schema():
         schema_file = os.path.join(os.path.dirname(__file__), "schemas", "xmldsig1-schema.xsd")
         _schema = etree.XMLSchema(etree.parse(schema_file))
     return _schema
+
+class VerifyResult(namedtuple("VerifyResult", "signed_data signed_xml signature_xml")):
+    """
+    The results of a verification return the signed data, the signed xml and the signature xml
+
+    :param signed_data: The binary data as it was signed (literally)
+    :type data: bytes
+    :param signed_xml: The signed data parsed as XML (or None if parsing failed)
+    :type signed_xml: ElementTree or None
+    :param signature_xml: The signature element parsed as XML
+    :type signed_xml: ElementTree
+    """
+    pass
 
 class xmldsig(object):
     """
@@ -592,8 +606,8 @@ class xmldsig(object):
 
         :raises: :py:class:`cryptography.exceptions.InvalidSignature`
 
-        :returns: XML ElementTree Element API compatible object representing the root of the signed payload.
-        :rtype: XML.ElementTree.Element
+        :returns: VerifyResult object with the signed data, signed xml and signature xml
+        :rtype: VerifyResult
 
         """
         self.hmac_key = hmac_key
@@ -617,9 +631,12 @@ class xmldsig(object):
         root = fromstring(etree.tostring(orig_root))
 
         if root.tag == ds_tag("Signature"):
-            signature = root
+            signature_ref = root
         else:
-            signature = self._find(root, "Signature", anywhere=True)
+            signature_ref = self._find(root, "Signature", anywhere=True)
+        
+        #HACK: deep copy won't keep root's namespaces
+        signature = fromstring(etree.tostring(signature_ref))
 
         if validate_schema:
             _get_schema().assertValid(signature)
@@ -634,7 +651,7 @@ class xmldsig(object):
         digest_value = self._find(reference, "DigestValue")
 
         payload = self._resolve_reference(root, reference, uri_resolver=uri_resolver)
-        payload_c14n = self._apply_transforms(payload, transforms, signature, c14n_algorithm)
+        payload_c14n = self._apply_transforms(payload, transforms, signature_ref, c14n_algorithm)
 
         if digest_value.text != self._get_digest(payload_c14n, self._get_digest_method(digest_algorithm)):
             raise InvalidDigest("Digest mismatch")
@@ -688,9 +705,10 @@ class xmldsig(object):
 
         #We return the signed XML (and only that) to ensure no access to unsigned data happens
         try:
-            return fromstring(payload_c14n)
+            payload_c14n_xml = fromstring(payload_c14n)
         except etree.XMLSyntaxError:
-            return payload_c14n
+            payload_c14n_xml = None
+        return VerifyResult(payload_c14n,payload_c14n_xml,signature)
 
     @property
     def namespaces(self):

--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -626,16 +626,16 @@ class xmldsig(object):
             orig_root = fromstring(self.data, parser=parser)
         else:
             orig_root = self.data
-        #HACK: deep copy won't keep root's namespaces resulting in an invalid digest
-        #We use a copy so we can modify the tree
+        # HACK: deep copy won't keep root's namespaces resulting in an invalid digest
+        # We use a copy so we can modify the tree
         root = fromstring(etree.tostring(orig_root))
 
         if root.tag == ds_tag("Signature"):
             signature_ref = root
         else:
             signature_ref = self._find(root, "Signature", anywhere=True)
-        
-        #HACK: deep copy won't keep root's namespaces
+
+        # HACK: deep copy won't keep root's namespaces
         signature = fromstring(etree.tostring(signature_ref))
 
         if validate_schema:
@@ -703,12 +703,12 @@ class xmldsig(object):
 
             self._verify_signature_with_pubkey(signed_info_c14n, raw_signature, key_value, signature_alg)
 
-        #We return the signed XML (and only that) to ensure no access to unsigned data happens
+        # We return the signed XML (and only that) to ensure no access to unsigned data happens
         try:
             payload_c14n_xml = fromstring(payload_c14n)
         except etree.XMLSyntaxError:
             payload_c14n_xml = None
-        return VerifyResult(payload_c14n,payload_c14n_xml,signature)
+        return VerifyResult(payload_c14n, payload_c14n_xml, signature)
 
     @property
     def namespaces(self):

--- a/test/test.py
+++ b/test/test.py
@@ -92,10 +92,10 @@ class TestSignXML(unittest.TestCase):
                     #Ensure the Signature is not part of the signed data
                     self.assertIsNone(_x.find(".//{http://www.w3.org/2000/09/xmldsig#}Signature"))
                     self.assertNotEqual(_x.tag, "{http://www.w3.org/2000/09/xmldsig#}Signature")
-                
+
                 #Ensure the signature was returned
                 self.assertEqual(_s.tag, "{http://www.w3.org/2000/09/xmldsig#}Signature")
-                    
+
                 if method == methods.enveloping:
                     with self.assertRaisesRegexp(InvalidInput, "Unable to resolve reference URI"):
                         xmldsig(signed_data).verify(id_attribute="X", **verify_kwargs)

--- a/test/test.py
+++ b/test/test.py
@@ -88,6 +88,11 @@ class TestSignXML(unittest.TestCase):
                 xmldsig(signed_data).verify(parser=parser, **verify_kwargs)
                 xmldsig(signed_data).verify(id_attribute="Id", **verify_kwargs)
 
+                if method == methods.enveloped:
+                    rv = xmldsig(signed_data).verify(id_attribute="Id", **verify_kwargs)
+                    #Check the enveloped signature was removed (this test won't work for nested signatures)
+                    self.assertIsNone(rv.find(".//{http://www.w3.org/2000/09/xmldsig#}Signature"))
+                    
                 if method == methods.enveloping:
                     with self.assertRaisesRegexp(InvalidInput, "Unable to resolve reference URI"):
                         xmldsig(signed_data).verify(id_attribute="X", **verify_kwargs)

--- a/test/test.py
+++ b/test/test.py
@@ -86,12 +86,15 @@ class TestSignXML(unittest.TestCase):
                 signed_data = etree.tostring(signed)
                 xmldsig(signed_data).verify(**verify_kwargs)
                 xmldsig(signed_data).verify(parser=parser, **verify_kwargs)
-                xmldsig(signed_data).verify(id_attribute="Id", **verify_kwargs)
+                (_d,_x,_s) = xmldsig(signed_data).verify(id_attribute="Id", **verify_kwargs)
 
-                if method == methods.enveloped:
-                    rv = xmldsig(signed_data).verify(id_attribute="Id", **verify_kwargs)
-                    #Check the enveloped signature was removed (this test won't work for nested signatures)
-                    self.assertIsNone(rv.find(".//{http://www.w3.org/2000/09/xmldsig#}Signature"))
+                if _x is not None:
+                    #Ensure the Signature is not part of the signed data
+                    self.assertIsNone(_x.find(".//{http://www.w3.org/2000/09/xmldsig#}Signature"))
+                    self.assertNotEqual(_x.tag, "{http://www.w3.org/2000/09/xmldsig#}Signature")
+                
+                #Ensure the signature was returned
+                self.assertEqual(_s.tag, "{http://www.w3.org/2000/09/xmldsig#}Signature")
                     
                 if method == methods.enveloping:
                     with self.assertRaisesRegexp(InvalidInput, "Unable to resolve reference URI"):


### PR DESCRIPTION
This pull request adds documentation on the deepcopy hack (to fix lxml namespace handling issues).

It changes the API so that the signed data is returned (both unparsed and parsed) after applying all the transformations, so the user will get what was signed (and only and exactly that).

Finally it also returns the signature node with the API change.

@kislyuk as this has an API change you may want to change major when releasing but I'm not sure how you tag your releases.